### PR TITLE
Minor tweaks to string_view_support_for_regex

### DIFF
--- a/include/regex
+++ b/include/regex
@@ -7188,12 +7188,12 @@ regex_replace(const basic_string<_CharT, _ST, _SA>& __s,
 template <class _Traits, class _CharT, class _ST, class _SA>
 inline _LIBCPP_INLINE_VISIBILITY
 basic_string<_CharT, _ST, _SA>
-regex_replace(const basic_string<_CharT, _ST, _SA> __s,
+regex_replace(const basic_string<_CharT, _ST, _SA>& __s,
               const basic_regex<_CharT, _Traits>& __e,
 			  const _CharT* __fmt,
               regex_constants::match_flag_type __flags = regex_constants::match_default)
 {
-    basic_string<_CharT, _ST> __r;
+    basic_string<_CharT, _ST, _SA> __r;
     _VSTD::regex_replace(back_inserter(__r), __s.begin(), __s.end(), __e, __fmt, __flags);
     return __r;
 }

--- a/include/regex
+++ b/include/regex
@@ -5251,7 +5251,7 @@ public:
     bool
     operator==(const sub_match& __x,
                const value_type& __y)
-        {return __x.compare(string_view_type(addressof(__y) ,1)) == 0;}
+        {return __x.compare(string_view_type(addressof(__y), 1)) == 0;}
 
     friend _LIBCPP_INLINE_VISIBILITY
     bool
@@ -5263,7 +5263,7 @@ public:
     bool
     operator<(const sub_match& __x,
               const value_type& __y)
-        {return __x.compare(string_view_type(addressof(__y) ,1)) < 0;}
+        {return __x.compare(string_view_type(addressof(__y), 1)) < 0;}
 
     friend _LIBCPP_INLINE_VISIBILITY
     bool
@@ -5669,6 +5669,7 @@ operator<=(const sub_match<_BiIter>& __x,
     return !(__y < __x);
 }
 #endif
+
 template <class _CharT, class _ST, class _BiIter>
 inline _LIBCPP_INLINE_VISIBILITY
 basic_ostream<_CharT, _ST>&
@@ -7103,7 +7104,7 @@ regex_replace(_OutputIterator __output_iter,
               const basic_regex<_CharT, _Traits>& __e, const _CharT* __fmt,
               regex_constants::match_flag_type __flags = regex_constants::match_default)
 {
-    return _VSTD::regex_replace(__output_iter, __first, __last, __e, basic_string_view<_CharT>(__fmt) , __flags);
+    return _VSTD::regex_replace(__output_iter, __first, __last, __e, basic_string_view<_CharT>(__fmt), __flags);
 }
 
 template <class _OutputIterator, class _BidirectionalIterator,
@@ -7116,7 +7117,7 @@ regex_replace(_OutputIterator __output_iter,
               const basic_string<_CharT, _ST, _SA>& __fmt,
               regex_constants::match_flag_type __flags = regex_constants::match_default)
 {
-    return _VSTD::regex_replace(__output_iter, __first, __last, __e, basic_string_view<_CharT>(__fmt) , __flags);
+    return _VSTD::regex_replace(__output_iter, __first, __last, __e, basic_string_view<_CharT>(__fmt), __flags);
 }
 
 #else

--- a/include/version
+++ b/include/version
@@ -226,7 +226,9 @@ __cpp_lib_void_t                                        201411L <type_traits>
 // # define __cpp_lib_is_constant_evaluated                201811L
 // # define __cpp_lib_list_remove_return_type              201806L
 // # define __cpp_lib_ranges                               201811L
-# define __cpp_lib_string_view_regex                    201901L
+# if !defined(_LIBCPP_NO_STRING_VIEW_REGEX)
+#   define __cpp_lib_string_view_regex                  201901L
+# endif
 // # define __cpp_lib_three_way_comparison                 201711L
 #endif
 


### PR DESCRIPTION
As one of my commit messages says:

> I believe the libc++ way to do this would actually be to use
> 
>     #if _LIBCPP_STD_VER >= 17 && !defined(_LIBCPP_NO_STRING_VIEW_REGEX)
> 
> everywhere that the current code uses
> 
>     #if defined(__cpp_lib_string_view_regex)
> 
> However, that's a lot of code churn and I'd rather let @mordante
> handle that himself if he wants to.

Also, I notice a lack of new unit tests; is that something you'd be interested in fixing?